### PR TITLE
CHANGED: Fixed Deprecated Ingress

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: cheddar
@@ -8,11 +8,14 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: cheddar
-          servicePort: 80
+          service:
+            name: cheddar
+            port:
+              number: 80
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: stilton
@@ -22,11 +25,14 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: stilton
-          servicePort: 80
+          service:
+            name: stilton
+            port:
+              number: 80
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: wensleydale
@@ -36,7 +42,10 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: wensleydale
-          servicePort: 80
+          service:
+            name: wensleydale
+            port:
+              number: 80
 ---


### PR DESCRIPTION
Changing the ingress.yaml should remove the deprecation errors caused by using a k8s v1.14+

When creating the ingresses resources `kubectl apply -f ingress.yaml`
![Screen Shot 2021-03-24 at 6 51 46 PM](https://user-images.githubusercontent.com/5805/112402412-1cd9f900-8cd2-11eb-8712-4b1d898f1df2.png)

When listing the ingress resources: `kubectl get ingress`

![Screen Shot 2021-03-24 at 6 54 04 PM](https://user-images.githubusercontent.com/5805/112402561-60346780-8cd2-11eb-8e68-2478b92b4b3d.png)
